### PR TITLE
Implement Tcp connection manager

### DIFF
--- a/DotNetServer.TCP/Services/BufferData.cs
+++ b/DotNetServer.TCP/Services/BufferData.cs
@@ -1,3 +1,3 @@
 ﻿namespace DotNetServer.TCP.Services;
 
-public record struct BufferData(byte[] data, int length); 
+public record struct BufferData(byte[] Data, int Length); 

--- a/DotNetServer.TCP/Services/ITcpConnectionManager.cs
+++ b/DotNetServer.TCP/Services/ITcpConnectionManager.cs
@@ -119,7 +119,10 @@ public class TcpConnectionManager : ITcpConnectionManager
         var tcpData = new TcpData(ipv4, tcpHeader, dataReceived, dataIndexStart);
         var result = await _connectionDictionary[key].HandleRequest(tcpData);
 
-        return result;
+        if (result.shouldDropConnection)
+            _connectionDictionary.Remove(key, out var _);
+
+        return (result.httpData, result.shouldReturn);
     }
 
     private TcpConnection CreateConnection(IPv4Header ipHeader, TcpHeader tcpHeader)

--- a/DotNetServer.TCP/Services/TcpConnection.cs
+++ b/DotNetServer.TCP/Services/TcpConnection.cs
@@ -4,11 +4,37 @@
 // check if it needs to be disposable
 public class TcpConnection 
 {
+    public TcpConnection(
+        TcpConnectionKey key,
+        TcpConnectionState state,
+        ushort? maximumSegmentSize,
+        byte? windowScale,
+        bool sackPermitted,
+        List<(uint, uint)> sackBlocks,
+        uint? timestampValue,
+        uint? timestampEchoReply,
+        ushort? timeoutInMs)
+    {
+        Key = key;
+        State = state;
+        MaximumSegmentSize = maximumSegmentSize;
+        WindowScale = windowScale;
+        SackPermitted = sackPermitted;
+        SackBlocks = sackBlocks;
+        TimestampValue = timestampValue;
+        TimestampEchoReply = timestampEchoReply;
+        TimeoutInMs = timeoutInMs;
+    }
+
     public TcpConnectionKey Key { get; }
     public TcpConnectionState State { get; }
-    public uint SequenceNumber { get;}
-    public uint AcknowledgementNumber { get; }
-    public int WindowSize { get; }
+    public ushort? MaximumSegmentSize { get; }
+    public byte? WindowScale { get; }
+    public bool? SackPermitted { get; }
+    public List<(uint, uint)> SackBlocks { get; }
+    public uint? TimestampValue { get; }
+    public uint? TimestampEchoReply { get; }
+    public ushort? TimeoutInMs { get; }
 
     public async Task<(HttpData httpData, bool shouldReturn)> HandleRequest(TcpData tcpData) =>
         throw new NotImplementedException();

--- a/DotNetServer.TCP/Services/TcpConnection.cs
+++ b/DotNetServer.TCP/Services/TcpConnection.cs
@@ -5,6 +5,7 @@
 public class TcpConnection 
 {
     public TcpConnection(
+        ITcpConnectionManager connectionManager,
         TcpConnectionKey key,
         TcpConnectionState state,
         ushort? maximumSegmentSize,
@@ -24,6 +25,7 @@ public class TcpConnection
         TimestampValue = timestampValue;
         TimestampEchoReply = timestampEchoReply;
         TimeoutInMs = timeoutInMs;
+        _connectionManager = connectionManager;
     }
 
     public TcpConnectionKey Key { get; }
@@ -35,6 +37,7 @@ public class TcpConnection
     public uint? TimestampValue { get; }
     public uint? TimestampEchoReply { get; }
     public ushort? TimeoutInMs { get; }
+    private readonly ITcpConnectionManager _connectionManager;
 
     public async Task<(HttpData httpData, bool shouldReturn, bool shouldDropConnection)> HandleRequest(TcpData tcpData) =>
         throw new NotImplementedException();

--- a/DotNetServer.TCP/Services/TcpConnection.cs
+++ b/DotNetServer.TCP/Services/TcpConnection.cs
@@ -36,7 +36,7 @@ public class TcpConnection
     public uint? TimestampEchoReply { get; }
     public ushort? TimeoutInMs { get; }
 
-    public async Task<(HttpData httpData, bool shouldReturn)> HandleRequest(TcpData tcpData) =>
+    public async Task<(HttpData httpData, bool shouldReturn, bool shouldDropConnection)> HandleRequest(TcpData tcpData) =>
         throw new NotImplementedException();
 
     public async Task<TcpData> Send(HttpData httpData) => throw new NotImplementedException(); 

--- a/DotNetServer.TCP/Services/TcpData.cs
+++ b/DotNetServer.TCP/Services/TcpData.cs
@@ -3,4 +3,4 @@ using DotNetServer.TCP.TCP;
 
 namespace DotNetServer.TCP.Services;
 
-public record struct TcpData(IpHeader ipHeader, TcpHeader tcpHeader, BufferData data, int? DataIndexStart);
+public record struct TcpData(IpHeader IpHeader, TcpHeader TcpHeader, BufferData Data, int? DataIndexStart);


### PR DESCRIPTION
Drafted TCP Connection manager: 

- Listens to byte array messages from listener
- Stores dictionary of active connections and drops the connection when requested by the connection
- Ability to receive http requests and then send those as byte arrays to listener
- Coordinated http (upper services), raw listener and tcp connections. 